### PR TITLE
Fixed the Extrapolation Error from map->odom transform when using the move_base navigation stack

### DIFF
--- a/src/als_ros/launch/mcl.launch
+++ b/src/als_ros/launch/mcl.launch
@@ -168,6 +168,7 @@
 
     <!-- localization Hz -->
     <arg name="localization_hz" default="10.0" />
+    <arg name="transform_tolerance" default="1.0" />
 
     <!-- Parameters used for randam particles in resampling (x, y, yaw).
          These parameters are used when use_augmented_mcl or add_random_particles_in_resampling is true. -->
@@ -307,5 +308,6 @@
         <param name="gmm_angular_variance" value="$(arg gmm_angular_variance)" type="double" />
 
         <param name="localization_hz" value="$(arg localization_hz)" type="double" />
+        <param name="transform_tolerance" value="$(arg transform_tolerance)" type="double" />
     </node >
 </launch >


### PR DESCRIPTION
Added a transform tolerance parameter to the MCL.h and mcl.launch file to solve the "Extrapolation Error: Lookup would require extrapolation into the future when looking up transform from frame [odom] to frame [map]"