### PR TITLE
Reset all reliabilities values

### DIFF
--- a/src/als_ros/include/als_ros/MCL.h
+++ b/src/als_ros/include/als_ros/MCL.h
@@ -1557,7 +1557,8 @@ private:
     }
 
     void resetReliabilities(void) {
-        reliabilities_.resize(particlesNum_, 0.5);
+        reliabilities_.resize(particlesNum_);
+        std::fill(reliabilities_.begin(), reliabilities_.end(), 0.5);
     }
 
     void rejectUnknownScan(void) {


### PR DESCRIPTION
Changelog
==
 - related to issue#12
 - adds `std::fill` to reset all values in `reliabiilities` vector
 - note that when `resize()` function call is made and if vector length goes from larger to smaller number, all elements within the vector remains the same, whereas using `resize()` to increase the size of the vector, the second argument given to the function will be added as vector elements.